### PR TITLE
fix(platform): correct macOS dynamic library suffix

### DIFF
--- a/src/drivers/js/runtimes/dll.js
+++ b/src/drivers/js/runtimes/dll.js
@@ -14,12 +14,15 @@ switch (platform) {
   case "windows":
     suffix = "dll";
     break;
-  case "dylib":
-    suffix = "dll";
+  case "darwin":
+    suffix = "dylib";
     break;
-  default:
+  case "linux":
     suffix = "so";
     break;
+  default:
+    console.error(`Platform ${platform} is not supported.`);
+    throw new Error(`Unsupported platform: ${platform}`);
 }
 
 export const coreDllPath = path.join(


### PR DESCRIPTION
This pull request addresses an issue with the platform-specific suffix handling in the dll.js file.